### PR TITLE
Remove old C header file from the dependencies

### DIFF
--- a/freenect.cabal
+++ b/freenect.cabal
@@ -23,7 +23,7 @@ Library
   Exposed-Modules:   Freenect Freenect.FFI
   Ghc-options:       -O2
   Build-depends:     base > 4 && < 5, vector
-  Includes:          libfreenect.h libfreenect_sync.h
+  Includes:          libfreenect.h 
   Extra-libraries:   freenect, freenect_sync
   C-sources:         cbits/freenect-helpers.c
   Include-dirs:      cbits


### PR DESCRIPTION
I tried to compile the library with the version libfreenect 0.1.2 but could not find libfreenect_sync.h anywere.
