### PR TITLE
Add support for setting AutoExposure/AutoWhiteBalance/RawColor and Mirro...

### DIFF
--- a/src/Freenect/FFI.hs
+++ b/src/Freenect/FFI.hs
@@ -89,6 +89,12 @@ foreign import ccall
 foreign import ccall
    "freenect.h freenect_set_led"
    freenect_set_led :: Ptr DeviceStruct -> CInt -> IO CInt
+
+
+foreign import ccall 
+   "freenect.h freenect_set_flag"
+   freenect_set_flag :: Ptr DeviceStruct -> CInt -> CInt -> IO CInt
+
 --------------------------------------------------------------------------------
 -- Helpers.
 


### PR DESCRIPTION
...rDepth/MirrorVideo

The current libfreenect drivers supports an interface to adjust some
camera settings like AutoExposure/AutoWhiteBalance/Mirroring. This
commit bridges these calls to the haskell interface.

Keep in mind: setFlag seems to be only working if the capture loop has
already started via startVideo/startDepth. It seems to me it's a bug
in libfreenect, where i have already written an issue.
