### PR TITLE
Add access to internal accelerations

### DIFF
--- a/src/Freenect/FFI.hs
+++ b/src/Freenect/FFI.hs
@@ -123,6 +123,31 @@ foreign import ccall
    freenect_get_mks_accel :: Ptr RawTiltState -> Ptr CDouble -> Ptr CDouble -> Ptr CDouble -> IO ()
 
 --------------------------------------------------------------------------------
+-- Audio
+
+foreign import ccall
+   "freenect_audio.h freenect_start_audio"
+   freenect_start_audio :: Ptr DeviceStruct -> IO CInt
+
+foreign import ccall 
+   "freenect_audio.h freenect_stop_audio"
+   freenect_stop_audio :: Ptr DeviceStruct -> IO CInt
+
+type AudioInCallback = Ptr DeviceStruct -> CInt -> Ptr Word32 -> Ptr Word32 -> Ptr Word32 -> Ptr Word32 -> Ptr Word16 -> Ptr CUChar -> IO ()
+
+foreign import ccall
+  "freenect.h freenect_set_audio_in_callback"
+  freenect_set_audio_in_callback
+    :: Ptr DeviceStruct
+    -> (FunPtr AudioInCallback)
+    -> IO ()
+
+foreign import ccall "wrapper"  
+  wrapAudioInCallback :: AudioInCallback -> IO (FunPtr AudioInCallback)
+
+
+
+--------------------------------------------------------------------------------
 -- Helpers.
 
 foreign import ccall


### PR DESCRIPTION
Add access to the accelerations values from the internal tilt state.
This commit uses freenect_get_mks_accell driver call.

Extracting the (x, y, z) values from the driver seems to be a little
messy due to some low-level conversion. But it works :]
