### PR TITLE
Find freenect via pkgconfig

### DIFF
--- a/freenect.cabal
+++ b/freenect.cabal
@@ -27,3 +27,4 @@ Library
   Extra-libraries:   freenect, freenect_sync
   C-sources:         cbits/freenect-helpers.c
   Include-dirs:      cbits
+  Pkgconfig-Depends: libfreenect


### PR DESCRIPTION
Using the provided pkgconfig file allows for more reliable detection of the flags required for finding freenect. For example, with this patch, the package now compiles cleanly on NixOS.
